### PR TITLE
:sparkles: bumps fourseven:scss package version to latest

### DIFF
--- a/package.js
+++ b/package.js
@@ -10,7 +10,7 @@ Package.onUse(function(api) {
   api.versionsFrom('1.3');
   api.use('ecmascript');
   api.use('underscore');
-  api.use('fourseven:scss@3.4.1');
+  api.use('fourseven:scss@4.4.5');
   api.use('std:accounts-ui@1.1.20');
 
   api.addFiles([


### PR DESCRIPTION
This resolves the dependency conflict with many other packages that also use fourseven:scss package.